### PR TITLE
Add create blog post feature

### DIFF
--- a/app/Controllers/PostController.php
+++ b/app/Controllers/PostController.php
@@ -15,4 +15,23 @@ class PostController
     {
         $this->model = new Post();
     }
+
+    public function create(Request $request, Response $response, $args): ResponseInterface
+    {
+        $data = $request->getParsedBody();
+
+        $post = $this->model->create($data);
+
+        $post['tags'] = json_decode($post['tags']);
+
+        $created_at = new \DateTime($post['created_at']);
+        $updated_at = new \DateTime($post['updated_at']);
+
+        $post['created_at'] = $created_at->format('Y-m-d\TH:i:s\Z');
+        $post['updated_at'] = $updated_at->format('Y-m-d\TH:i:s\Z');
+
+        $response->getBody()->write(json_encode($post));
+
+        return $response->withStatus(201);
+    }
 }

--- a/app/Helpers/Validator.php
+++ b/app/Helpers/Validator.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Helpers;
+
+class Validator
+{
+    public static $validation_errors = [], $validated_data = [];
+
+    public static function setRules(array $data, array $rules): object
+    {
+
+        foreach ($rules as $field => $ruleset) {
+            $value = $data[$field] ?? null;
+
+            foreach ($ruleset as $rule) {
+                if (!isset(self::$validation_errors[$field])) {
+                    $validated_value = self::validate($value, $rule, $field, $data);
+                }
+            }
+
+            self::$validated_data[$field] = $validated_value ?? null;
+        }
+
+        return new Validator();
+    }
+
+    public static function validate($value, string $rule, string $field, array $data)
+    {
+        if ($rule === "required" && empty($value)) {
+            self::setValidationError($field, $field . " field is required.");
+        }
+
+        if (!empty($value)) {
+            if ($rule === "alpha" && !preg_match("/^[a-zA-Z\s'-]+$/", $value)) {
+                self::setValidationError($field, $field . " input may only contain letters, spaces, apostrof (') and hyphens (-).");
+            }
+
+            if ($rule === "alpha_num") {
+                if (!preg_match("/^[a-zA-Z0-9._-]+$/", $value)) {
+                    self::setValidationError($field, $field . " input may only contain letters, numbers, periods (.), underscores (_), and hyphens (-).");
+                }
+            }
+
+            if ($rule === "alpha_num_space") {
+                if (!preg_match("/^[a-zA-Z0-9. _-]+$/", $value)) {
+                    self::setValidationError($field, $field . " input may only contain letters, spaces, numbers, periods (.), underscores (_), and hyphens (-).");
+                }
+            }
+
+            if ($rule === "array_string") {
+                if (!is_array($value)) {
+                    self::setValidationError($field, $field . ' input must be a valid array.');
+                } else {
+                    foreach ($value as $val) {
+                        if (!is_string($val)) {
+                            self::setValidationError($field, $field . " input array must contain only strings.");
+                        }
+
+                        if (empty($val)) {
+                            self::setValidationError($field, $field . " input array must not contain empty strings.");
+                        }
+                    }
+                }
+            }
+
+            if ($rule === "num" && !is_numeric($value)) {
+                self::setValidationError($field, $field . " input must be numeric");
+            }
+
+            if ($rule === "lowercase" && $value !== strtolower($value)) {
+                self::setValidationError($field, $field . " input letters must be lowercase.");
+            }
+
+            if (strpos($rule, "min_length") !== false && strpos($rule, ":") !== false) {
+                $rule = explode(":", $rule)[1];
+
+                if (strlen($value) < (int)$rule) {
+                    self::setValidationError($field, $field . " input must be at least {$rule} characters long.");
+                }
+            }
+
+            if (strpos($rule, "max_length") !== false && strpos($rule, ":") !== false) {
+                $rule = explode(":", $rule)[1];
+
+                if (strlen($value) > (int)$rule) {
+                    self::setValidationError($field, $field . " input must not exceed {$rule} characters.");
+                }
+            }
+
+            if ($rule === "numeric" && !is_numeric($value)) {
+                self::setValidationError($field, $field . " input must be numeric.");
+            }
+
+            if ($rule === "email") {
+                $value = filter_var($value, FILTER_SANITIZE_EMAIL);
+
+                if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                    self::setValidationError($field, $field . " input must be a valid email address.");
+                }
+            }
+
+            if (strpos($rule, "match") !== false && strpos($rule, ":") !== false) {
+                $match = explode(":", $rule);
+                if ($value !== $data[$match[1]]) {
+                    self::setValidationError($field, $field . " doesn't match.");
+                }
+            }
+
+            if ($rule === "phone_number" && !preg_match("/^08[0-9]{10,12}$/", $value)) {
+                self::setValidationError($field, $field . " input must be a valid phone number.");
+            }
+
+            if ($rule === "date") {
+                if (!preg_match("/^\d{4}-\d{2}-\d{2}$/", $value)) {
+                    self::setValidationError($field, $field . " input format must be Y-m-d.");
+                    return;
+                }
+
+                $parts = explode("-", $value);
+                if (!checkdate($parts[1], $parts[2], $parts[0])) {
+                    self::setValidationError($field, $field . " input must be a valid date.");
+                }
+            }
+        }
+
+        return $value;
+    }
+
+    public static function setValidationError($field, $message): void
+    {
+        self::$validation_errors[$field] = $message;
+    }
+
+    public function hasValidationErrors(): bool
+    {
+        return !empty(self::$validation_errors);
+    }
+
+    public static function hasValidationError($field): bool
+    {
+        return isset(self::$validation_errors[$field]);
+    }
+
+    public function getValidationErrors(): array
+    {
+        $validation_errors = self::$validation_errors ?? "";
+        self::$validation_errors = [];
+
+        return $validation_errors;
+    }
+
+    public function validated(): array
+    {
+        return empty(self::$validation_errors) ? self::$validated_data : [];
+    }
+}

--- a/app/Middlewares/JsonBodyParserMiddleware.php
+++ b/app/Middlewares/JsonBodyParserMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Middlewares;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
+
+class JsonBodyParserMiddleware implements MiddlewareInterface
+{
+    public function process(Request $request, RequestHandler $handler): Response
+    {
+        $contentType = $request->getHeaderLine('Content-Type');
+
+        if (strstr($contentType, 'application/json')) {
+            $contents = json_decode(file_get_contents('php://input'), true);
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $request = $request->withParsedBody($contents);
+            }
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -27,4 +27,18 @@ final class Post extends Model
             die("Error creating table: " . $this->conn->error);
         }
     }
+
+    public function create(array $data)
+    {
+        $stmt = $this->conn->prepare("INSERT INTO $this->table (title, content, category, tags) VALUES (?, ?, ?, ?)");
+        $stmt->bind_param("ssss", $data['title'], $data['content'], $data['category'], $data['tags']);
+
+        if ($stmt->execute() === false) {
+            die("Error creating post: " . $stmt->error);
+        }
+
+        $result = $this->conn->query("SELECT * FROM $this->table WHERE id = " . $stmt->insert_id);
+
+        return $result->fetch_assoc();
+    }
 }

--- a/app/Validators/PostValidator.php
+++ b/app/Validators/PostValidator.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Validators;
+
+use App\Helpers\Validator;
+
+class PostValidator
+{
+    public static function validate(array $data)
+    {
+        return Validator::setRules($data, [
+            'title' => ['required', 'alpha_num_space', 'min_length:3', 'max_length:255'],
+            'content' => ['required', 'max_length:65535'],
+            'tags' => ['array_string']
+        ]);
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,7 @@ use Middlewares\TrailingSlash;
 use App\Controllers\PostController;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use App\Middlewares\JsonBodyParserMiddleware;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -20,6 +21,8 @@ $app->addErrorMiddleware(true, true, true)
 	->forceContentType('application/json');
 
 $app->add(new TrailingSlash(trailingSlash: false));
+
+$app->add(new JsonBodyParserMiddleware());
 
 $app->get('/', function (Request $request, Response $response, $args) {
 	$response->getBody()->write('Hello World');

--- a/public/index.php
+++ b/public/index.php
@@ -2,6 +2,7 @@
 
 use Slim\Factory\AppFactory;
 use Middlewares\TrailingSlash;
+use App\Controllers\PostController;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -24,5 +25,7 @@ $app->get('/', function (Request $request, Response $response, $args) {
 	$response->getBody()->write('Hello World');
 	return $response;
 });
+
+$app->post('/posts', [PostController::class, 'create']);
 
 $app->run();


### PR DESCRIPTION
## Description

Introduce a new feature to create blog posts, including validation for post data and a middleware to parse JSON request bodies. This update enhances the PostController and adds necessary validation rules, improving data integrity and user experience.

## Type of PR

This PR is a feature

## Checklist

- [x] Create a new blog post using the `POST` method

```http
POST /posts
{
  "title": "My First Blog Post",
  "content": "This is the content of my first blog post.",
  "category": "Technology",
  "tags": ["Tech", "Programming"]
}
```
- [x] Each blog post should have the following fields:

```json
{
  "title": "My First Blog Post",
  "content": "This is the content of my first blog post.",
  "category": "Technology",
  "tags": ["Tech", "Programming"]
}
```

- [x] The endpoint should validate the request body and return a `201 Created` status code with the newly created blog post i.e.

```json
{
  "id": 1,
  "title": "My First Blog Post",
  "content": "This is the content of my first blog post.",
  "category": "Technology",
  "tags": ["Tech", "Programming"],
  "createdAt": "2021-09-01T12:00:00Z",
  "updatedAt": "2021-09-01T12:00:00Z"
}
```

- [x] or a 400 Bad Request status code with error messages in case of validation errors.

## Closed Issue

Closes #1 