### PR TITLE
Add get a single blog post feature

### DIFF
--- a/app/Controllers/PostController.php
+++ b/app/Controllers/PostController.php
@@ -36,6 +36,23 @@ class PostController
         return $response->withStatus(201);
     }
 
+    public function show(Request $request, Response $response, $args): ResponseInterface
+    {
+        $id = $args['id'];
+
+        $response = $response->withAddedHeader('Content-Type', 'application/json');
+
+        $post = $this->model->getById($id);
+
+        if (!$post) {
+            $response->getBody()->write(json_encode(['message' => 'Post not found']));
+            return $response->withStatus(404);
+        }
+
+        $response->getBody()->write(json_encode($this->formatPost($post)));
+        return $response;
+    }
+
     private function formatPost($post)
     {
         $post['tags'] = json_decode($post['tags']);

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -37,7 +37,12 @@ final class Post extends Model
             die("Error creating post: " . $stmt->error);
         }
 
-        $result = $this->conn->query("SELECT * FROM $this->table WHERE id = " . $stmt->insert_id);
+        return $this->getById($stmt->insert_id);
+    }
+
+    public function getById(int $id)
+    {
+        $result = $this->conn->query("SELECT * FROM $this->table WHERE id = $id");
 
         return $result->fetch_assoc();
     }

--- a/public/index.php
+++ b/public/index.php
@@ -30,5 +30,6 @@ $app->get('/', function (Request $request, Response $response, $args) {
 });
 
 $app->post('/posts', [PostController::class, 'create']);
+$app->get('/posts/{id}', [PostController::class, 'show']);
 
 $app->run();


### PR DESCRIPTION
## Description

Implement a new endpoint to fetch a single blog post by its ID, enhancing the blog's API functionality.

## Type of PR

This PR is a feature

## Checklist

- [x] Get a single blog post using the `GET` method

```http
GET /posts/1
```

- [x] The endpoint should return a `200 OK` status code with the blog post i.e.

```json
{
  "id": 1,
  "title": "My First Blog Post",
  "content": "This is the content of my first blog post.",
  "category": "Technology",
  "tags": ["Tech", "Programming"],
  "createdAt": "2021-09-01T12:00:00Z",
  "updatedAt": "2021-09-01T12:00:00Z"
}
```

- [x] or a `404 Not Found` status code if the blog post was not found.

## Closed Issue

Closes #4 
