### PR TITLE
Add get all blog posts feature

### DIFF
--- a/app/Controllers/PostController.php
+++ b/app/Controllers/PostController.php
@@ -17,6 +17,20 @@ class PostController
         $this->model = new Post();
     }
 
+    public function index(Request $request, Response $response, $args): ResponseInterface
+    {
+        $response = $response->withAddedHeader('Content-Type', 'application/json');
+
+        $posts = $this->model->getAll();
+
+        foreach ($posts as $key => $post) {
+            $posts[$key] = $this->formatPost($post);
+        }
+
+        $response->getBody()->write(json_encode($posts));
+        return $response;
+    }
+
     public function create(Request $request, Response $response, $args): ResponseInterface
     {
         $data = $request->getParsedBody() ?? [];

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -46,4 +46,11 @@ final class Post extends Model
 
         return $result->fetch_assoc();
     }
+
+    public function getAll()
+    {
+        $result = $this->conn->query("SELECT * FROM $this->table");
+
+        return $result->fetch_all(MYSQLI_ASSOC);
+    }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -31,5 +31,6 @@ $app->get('/', function (Request $request, Response $response, $args) {
 
 $app->post('/posts', [PostController::class, 'create']);
 $app->get('/posts/{id}', [PostController::class, 'show']);
+$app->get('/posts', [PostController::class, 'index']);
 
 $app->run();


### PR DESCRIPTION
## Description

Implement a method in the PostController and Post model to fetch all blog posts, along with the necessary route for accessing this feature.

## Type of PR

This PR is a feature.

## Checklist

- [x] Get all blog posts using the `GET` method

```http
GET /posts
```

- [x] The endpoint should return a `200 OK` status code with an array of blog posts i.e.

```json
[
  {
    "id": 1,
    "title": "My First Blog Post",
    "content": "This is the content of my first blog post.",
    "category": "Technology",
    "tags": ["Tech", "Programming"],
    "createdAt": "2021-09-01T12:00:00Z",
    "updatedAt": "2021-09-01T12:00:00Z"
  },
  {
    "id": 2,
    "title": "My Second Blog Post",
    "content": "This is the content of my second blog post.",
    "category": "Technology",
    "tags": ["Tech", "Programming"],
    "createdAt": "2021-09-01T12:30:00Z",
    "updatedAt": "2021-09-01T12:30:00Z"
  }
]
```

## Closed Issue

Closes #5 