### PR TITLE
Add delete blog post feature

### DIFF
--- a/app/Controllers/PostController.php
+++ b/app/Controllers/PostController.php
@@ -92,6 +92,25 @@ class PostController
         return $response;
     }
 
+    public function delete(Request $request, Response $response, $args): ResponseInterface
+    {
+        $id = $args['id'];
+
+        $response = $response->withAddedHeader('Content-Type', 'application/json');
+
+        $post = $this->model->getById($id);
+
+        if (!$post) {
+            $response->getBody()->write(json_encode(['message' => 'Post not found']));
+            return $response->withStatus(404);
+        }
+
+        $this->model->delete($id);
+
+        $response->getBody()->write(json_encode(['message' => 'Post deleted']));
+        return $response->withStatus(204);
+    }
+
     private function formatPost($post)
     {
         $post['tags'] = json_decode($post['tags']);

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -65,4 +65,16 @@ final class Post extends Model
 
         return $this->getById($id);
     }
+
+    public function delete(int $id)
+    {
+        $stmt = $this->conn->prepare("DELETE FROM $this->table WHERE id = ?");
+        $stmt->bind_param("i", $id);
+
+        if ($stmt->execute() === false) {
+            die("Error deleting post: " . $stmt->error);
+        }
+
+        return true;
+    }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -33,5 +33,6 @@ $app->post('/posts', [PostController::class, 'create']);
 $app->get('/posts/{id}', [PostController::class, 'show']);
 $app->get('/posts', [PostController::class, 'index']);
 $app->put('/posts/{id}', [PostController::class, 'update']);
+$app->delete('/posts/{id}', [PostController::class, 'delete']);
 
 $app->run();


### PR DESCRIPTION
## Description

Implement a feature to delete blog posts, including the necessary methods in the PostController and Post model, as well as the corresponding route.

## Type of PR

This PR is a feature

## Checklist

# Delete Blog Post

- [x] Delete an existing blog post using the `DELETE` method

```http
DELETE /posts/1
```

- [x] The endpoint should return a `204 No Content` status code if the blog post was successfully deleted 
- [x] or a `404 Not Found` status code if the blog post was not found.

## Closed Issue

Closes #3 