### PR TITLE
Add filter by term functionality for posts

### DIFF
--- a/app/Controllers/PostController.php
+++ b/app/Controllers/PostController.php
@@ -21,7 +21,9 @@ class PostController
     {
         $response = $response->withAddedHeader('Content-Type', 'application/json');
 
-        $posts = $this->model->getAll();
+        $term = $request->getQueryParams()['term'] ?? null;
+
+        $posts = $this->model->getAll($term);
 
         foreach ($posts as $key => $post) {
             $posts[$key] = $this->formatPost($post);

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -47,9 +47,15 @@ final class Post extends Model
         return $result->fetch_assoc();
     }
 
-    public function getAll()
+    public function getAll(string $term = null)
     {
-        $result = $this->conn->query("SELECT * FROM $this->table");
+        $sql = "SELECT * FROM $this->table";
+
+        if ($term) {
+            $sql .= " WHERE title LIKE '%$term%' OR content LIKE '%$term%' OR category LIKE '%$term%' OR tags LIKE '%$term%'";
+        }
+
+        $result = $this->conn->query($sql);
 
         return $result->fetch_all(MYSQLI_ASSOC);
     }


### PR DESCRIPTION
## Description

Implement a term query parameter to enable filtering of posts by title, content, category, and tags. Update the PostController and Post model to support this new functionality.

## Type of PR

This PR is a feature.

## Checklist

- [x] While retrieving posts, user can also filter posts by a search term. Do a wildcard search on the title, content or category fields of the blog posts. For example:

```http
GET /posts?term=tech
```

- [x] This should return all blog posts that have the term “tech” in their title, content or category. Use a simple SQL query if  using a SQL database or a similar query for a NoSQL database.

## Closed Issue

Closes #6 